### PR TITLE
Update AdbPaste.py

### DIFF
--- a/AdbPaste.py
+++ b/AdbPaste.py
@@ -85,6 +85,8 @@ class AdbPaste:
 	#// there is nothing i can do when calling it on windows because adb will just
 	#// pass it forward to sh and things break.
 	trouble = [' ', '\n', '	'] # i think space is only needed in adb.exe->sh... when running directly in unix it may not be needed
+	if sys.platform != "win32":
+		trouble.append('`')
 	inconvenience = [';', ')' ,'(', "'", '\\', '&', '#', '<', '>', '|']
 
 	def __init__(self, input_string=""):


### PR DESCRIPTION
Fixes issue on unix (testing on linux) where a backtick in a file passed in via the --file option will cause the script to stop early and fail.

Unsure if this is necessary on Windows, but since you seem to be running (or at least testing) on Windows, I figure you didn't encounter any such error.
